### PR TITLE
fix: code quality — SonarCloud, CodeQL, and linting improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run behave
         env:
           PYTHONIOENCODING: "utf-8"
-        run: poetry run behave tests/features/ --tags "not @wip"
+        run: poetry run behave
 
       - name: Upload test results
         if: always()

--- a/poetry.lock
+++ b/poetry.lock
@@ -3979,6 +3979,21 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
+name = "vulture"
+version = "2.16"
+description = "Find dead code"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee"},
+    {file = "vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717"},
+]
+
+[package.dependencies]
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+
+[[package]]
 name = "wcwidth"
 version = "0.7.0"
 description = "Measures the displayed width of unicode strings in a terminal"
@@ -4212,4 +4227,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "42b4dd3e0f32a1afa1ca7195eea7f738516e16df9d2a9da97cacc3019ad73d31"
+content-hash = "5346f6c75c8a591016b9bcd326ba41eda5ecb14956aef183b4dec64175351546"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,7 @@ output = "build/coverage.xml"
 paths = [
     "tests/features/"
 ]
+tags = ["not @wip"]
 
 [tool.pymarkdown]
 # MD010 - no hard tabs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ target-version = "py312"
 
 [tool.ruff.lint]
 select = [
-    "E", "F", "W", "B", "C", "I", "S110", "A", "N",
+    "E", "F", "W", "B", "C", "I", "S110", "A", "N", "ARG",
     # TODO(009-quality-uplift): Enable UP rule set — 124 violations exceed the 20-violation cap;
     # most are auto-fixable (ruff --fix) but UP042/UP032 need semantic review
     "UP",
@@ -145,11 +145,14 @@ exclude = [
     "*.log",
 ]
 
+[tool.ruff.lint.mccabe]
+max-complexity = 15
+
 [tool.ruff.lint.flake8-bandit]
 check-typed-exception = true
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["S101", "N999", "N817"]  # S101: assertions OK in tests; N999: test files mirror camelCase reader/writer names; N817: ET is the canonical ElementTree alias
+"tests/**" = ["S101", "N999", "N817", "ARG"]  # S101: assertions OK in tests; N999: test files mirror camelCase reader/writer names; N817: ET is the canonical ElementTree alias; ARG: unused params are normal in BDD steps, mocks, and sentinel lambdas
 
 [tool.ruff.format]
 quote-style = "double"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
     "snakeviz>=2.2.2,<3.0.0",
     "locust (>=2.43.3,<3.0.0)",
     "ipykernel (>=7.2.0,<8.0.0)",
+    "vulture (>=2.16,<3.0)",
 ]
 
 testing = [  # runtime tooling required to exercise the test suite

--- a/scripts/pre_commit_checks.sh
+++ b/scripts/pre_commit_checks.sh
@@ -20,6 +20,7 @@ run_quiet "poetry install"  poetry install
 run_quiet "poetry sync"     poetry sync
 run_quiet "pymarkdown lint" poetry run pymarkdownlnt fix *.md specs/*.md
 run_quiet "ruff check"      poetry run ruff check src/ tests/ --fix
+run_quiet "vulture"         poetry run vulture src/ --min-confidence 80
 run_quiet "pyright"         poetry run pyright src/ tests/
 run_quiet "mypy"            poetry run mypy src/
 run_quiet "pytest unit"     poetry run pytest tests/unit/

--- a/scripts/pre_push_checks.sh
+++ b/scripts/pre_push_checks.sh
@@ -25,7 +25,7 @@ run_quiet "sync requirements.txt"  poetry export --without-hashes --with docs --
 # --- Security Checks ---
 # poetry run snyk test --package-manager=poetry || true
 
-run_quiet "BDD acceptance tests"    poetry run behave -t "not @wip"
+run_quiet "BDD acceptance tests"    poetry run behave
 
 run_quiet "pytest unit (coverage)"  poetry run pytest tests/unit/ --cov-fail-under=79 --cov=src --cov-report=term-missing
 run_quiet "pytest integration"      poetry run pytest tests/integration/ tests/fixtures/

--- a/specs/TECHNICAL.md
+++ b/specs/TECHNICAL.md
@@ -268,6 +268,13 @@ The following patterns ensure data fidelity when reading, modifying, and writing
 - **Automated Testing**: Integrate all automated tests (unit, integration, BDD) into the CI pipeline to run on every commit.
 - **Linting and Formatting**: Integrate `Ruff` or similar tools into the pipeline to enforce code style and quality.
 - **Deployment Strategy**: Define clear deployment strategies (e.g., blue-green, canary releases) and automate deployment processes where feasible.
+- **Behave Tag Filtering**: Configure default tag exclusions in `pyproject.toml` under `[tool.behave]` — this is the single source of truth applied to all invocations (pre-commit, CI, VS Code extension). Do not duplicate the flag in individual scripts. Scenarios tagged `@wip` signal unimplemented step definitions; running them produces `status="error"` in JUnit XML which tools like `behave-vsc` cannot parse.
+
+```toml
+[tool.behave]
+paths = ["tests/features/"]
+tags = ["not @wip"]
+```
 
 ## API Design Principles
 
@@ -297,6 +304,7 @@ The following patterns ensure data fidelity when reading, modifying, and writing
 
 - **Testing Frameworks**: `pytest`, `pytest-mock`, `behave` (for BDD)
 - **Linters/Formatters**: `Ruff`
+- **Dead Code Detection**: `vulture` (run with `--min-confidence 80`; add to pre-commit checks)
 - **Type Checkers**: `MyPy`, `PyRight`
 - **Build/Dependency Management**: This repository uses Poetry for dependency/deployment scripts, so prefer `poetry install`, `poetry run`, and pipeline scripts defined in `pyproject.toml`. Keep `requirements.txt` in sync with `pyproject.toml`. Fall back to `uv` only when Poetry lacks the needed capability or when a spec explicitly says so.
 - **Package Installation/Running**: `UV`
@@ -309,6 +317,14 @@ The following patterns ensure data fidelity when reading, modifying, and writing
 ### Python Specifics
 
 - **Dataclass Argument Order**: When defining dataclasses, ensure all non-default arguments (fields without default values) are listed before any arguments with default values. Failing to do so will result in a `TypeError`.
+- **Side-Effect Imports**: When importing a module solely for its decorator side effects (e.g., Behave step registration), use `from package import module` rather than `import package.module.path`. The latter form binds only the top-level package name, which CodeQL flags as unused. Declare `__all__` in the aggregator file to satisfy both ruff (F401) and CodeQL:
+
+```python
+from tests.features.layout import auto_format_steps, auto_layout_steps
+__all__ = ["auto_format_steps", "auto_layout_steps"]
+```
+
+- **Explicit Re-Exports**: Use `from module import Name as Name` (same-name alias) when building a public API shim. Ruff recognises this pattern as an intentional re-export and does not raise F401 — `# noqa: F401` is redundant on these lines.
 - **Avoiding Circular Imports**: Be mindful of import dependencies between modules. A common pitfall occurs when module A imports from module B, and module B simultaneously imports from module A, leading to `ImportError`. Refactor code to break these cycles, often by moving shared logic or type hints to a separate, lower-level module.
 - **Import Style for `src` Layouts**: For projects using a `src` layout (where application code resides in a `src` directory), ensure `src` is correctly added to `PYTHONPATH` (e.g., via `pyproject.toml` or build tools). Subsequently, remove redundant `src.` prefixes from import statements (e.g., use `from frictionless_architect.models.module import ...` instead of `from src.models.module import ...`) for cleaner, more idiomatic Python.
 - **Mypy Configuration for `src` Layouts**: For projects utilizing a `src` directory structure, correctly configuring `mypy` in `pyproject.toml` is crucial to avoid "Duplicate module named" or `[import-untyped]` errors.
@@ -415,11 +431,24 @@ pysonar --sonar-token=<token-from-.secrets>
 
 You can also query SonarCloud public API for the current critical issues list; the token value is stored in the project `.env` file (look for the SONAR_TOKEN key there) and should not be committed.
 
-```
+```text
 https://sonarcloud.io/api/issues/search?projectKeys=pyArchimate_pyArchimate&severities=BLOCKER,CRITICAL,MAJOR,MINOR&statuses=OPEN,CONFIRMED
 ```
 
+### Local Tool Coverage for SonarCloud Rules
+
+The table below maps common SonarCloud rules to the local tools that catch them at pre-commit time. Use this to configure tooling so issues are caught before CI rather than after.
+
+| SonarCloud Rule | Description | Local Tool | Notes |
+|---|---|---|---|
+| S1172 | Unused function parameter | ruff `ARG` | Enabled for `src/`; excluded from `tests/` (mocks, BDD steps) |
+| S1940 | Chained `startswith`/`endswith` | _(no ruff equivalent)_ | Fix manually: use tuple arg `str.startswith(("a", "b"))` |
+| S3776 | Cognitive complexity > 15 | ruff `C901` (`max-complexity=15`) | C901 measures McCabe complexity — different metric, may not flag same functions |
+| Unused global variable | Module-level dead code | `vulture --min-confidence 80` | Gap: vulture skips `_`-prefixed constants by design; CodeQL is authoritative |
+| Wildcard `import *` | Namespace pollution | ruff `F403` | Already enabled; do not suppress with `# noqa` — fix the import instead |
+
 ### SonarCloud Remediation Workflow
+
 When new SonarCloud issues appear on `main`, follow this sequence:
 
 1. Pull the latest `main` and request the open issues via the API (same URL as above); review the payload for every problem marked `OPEN`.

--- a/src/pyArchimate/pyArchimate.py
+++ b/src/pyArchimate/pyArchimate.py
@@ -13,38 +13,38 @@ from .constants import (
 from .constants import (
     DEFAULT_THEME as default_theme,  # noqa: F401,N811  # lowercase alias is the stable public API name
 )
-from .constants import RGBA as RGBA  # noqa: F401
-from .element import Element as Element  # noqa: F401
+from .constants import RGBA as RGBA
+from .element import Element as Element
 from .element import set_id as set_id
-from .enums import AccessType as AccessType  # noqa: F401,E501
+from .enums import AccessType as AccessType
 from .enums import ArchiType as ArchiType
 from .enums import Readers as Readers
 from .enums import TextAlignment as TextAlignment
 from .enums import TextPosition as TextPosition
 from .enums import Writers as Writers
-from .exceptions import ArchimateConceptTypeError as ArchimateConceptTypeError  # noqa: F401,E501
+from .exceptions import ArchimateConceptTypeError as ArchimateConceptTypeError
 from .exceptions import ArchimateRelationshipError as ArchimateRelationshipError
-from .helpers.diagram import get_or_create_connection as get_or_create_connection  # noqa: F401,E501
+from .helpers.diagram import get_or_create_connection as get_or_create_connection
 from .helpers.diagram import get_or_create_node as get_or_create_node
-from .helpers.logging import log as log  # noqa: F401,E501
+from .helpers.logging import log as log
 from .helpers.logging import log_set_level as log_set_level
 from .helpers.logging import log_to_file as log_to_file
 from .helpers.logging import log_to_stderr as log_to_stderr
-from .helpers.properties import check_invalid_conn as check_invalid_conn  # noqa: F401,E501
+from .helpers.properties import check_invalid_conn as check_invalid_conn
 from .helpers.properties import check_invalid_nodes as check_invalid_nodes
 from .helpers.properties import embed_props as embed_props
 from .helpers.properties import expand_props as expand_props
-from .model import Model as Model  # noqa: F401
+from .model import Model as Model
 from .model import default_color as default_color
-from .relationship import Relationship as Relationship  # noqa: F401,E501
+from .relationship import Relationship as Relationship
 from .relationship import check_valid_relationship as check_valid_relationship
 from .relationship import get_default_rel_type as get_default_rel_type
-from .view import Connection as Connection  # noqa: F401,E501
+from .view import Connection as Connection
 from .view import Node as Node
 from .view import Point as Point
 from .view import Position as Position
 from .view import Profile as Profile
 from .view import View as View
-from .writers import register_writer as register_writer  # noqa: F401
+from .writers import register_writer as register_writer
 
 __all__ = [name for name in globals() if not name.startswith("_")]  # pyright: ignore[reportUnsupportedDunderAll]

--- a/src/pyArchimate/view/layout/algorithms/hierarchical.py
+++ b/src/pyArchimate/view/layout/algorithms/hierarchical.py
@@ -196,7 +196,7 @@ class HierarchicalLayout(LayoutAlgorithm):
         self,
         _node_id: int,
         _layer_index: int,
-        nodes: list[Any],
+        _nodes: list[Any],
         _layer_constraint: LayerConstraint,
     ) -> bool:
         """Check if assigning node to layer respects ArchiMate layer ordering.

--- a/src/pyArchimate/view/layout/layout_engine.py
+++ b/src/pyArchimate/view/layout/layout_engine.py
@@ -6,8 +6,6 @@ from typing import Any
 
 from .routing.layer_constraints import ArchiMateLayer
 
-_ROWS_PER_LAYER = 3  # max nodes per row within a layer band before wrapping
-
 
 def get_layer_priority(element_type: str) -> int:
     """Return layer priority (0=topmost) for an ArchiMate element type string."""

--- a/src/pyArchimate/view/layout/layout_engine.py
+++ b/src/pyArchimate/view/layout/layout_engine.py
@@ -6,17 +6,6 @@ from typing import Any
 
 from .routing.layer_constraints import ArchiMateLayer
 
-# Extended layer priority map including all ArchiMate layers
-_LAYER_PRIORITY: dict[str, int] = {
-    "motivation": 0,
-    "business": 1,
-    "application": 2,
-    "technology": 3,
-    "physical": 4,
-    "implementation": 5,
-    "migration": 5,
-}
-
 _ROWS_PER_LAYER = 3  # max nodes per row within a layer band before wrapping
 
 

--- a/tests/features/steps/layout_steps.py
+++ b/tests/features/steps/layout_steps.py
@@ -1,6 +1,8 @@
 """Import layout step modules so Behave can discover their step definitions."""
 
-import tests.features.layout.auto_format_steps  # noqa: F401
-import tests.features.layout.auto_layout_steps  # noqa: F401
-import tests.features.layout.customize_layout_steps  # noqa: F401
-import tests.features.layout.svg_export_steps  # noqa: F401
+from tests.features.layout import (
+    auto_format_steps,  # noqa: F401
+    auto_layout_steps,  # noqa: F401
+    customize_layout_steps,  # noqa: F401
+    svg_export_steps,  # noqa: F401
+)

--- a/tests/features/steps/layout_steps.py
+++ b/tests/features/steps/layout_steps.py
@@ -1,8 +1,10 @@
 """Import layout step modules so Behave can discover their step definitions."""
 
 from tests.features.layout import (
-    auto_format_steps,  # noqa: F401
-    auto_layout_steps,  # noqa: F401
-    customize_layout_steps,  # noqa: F401
-    svg_export_steps,  # noqa: F401
+    auto_format_steps,
+    auto_layout_steps,
+    customize_layout_steps,
+    svg_export_steps,
 )
+
+__all__ = ["auto_format_steps", "auto_layout_steps", "customize_layout_steps", "svg_export_steps"]

--- a/tests/features/steps/layout_steps.py
+++ b/tests/features/steps/layout_steps.py
@@ -1,6 +1,6 @@
-"""Re-export layout step definitions so Behave can discover them from the steps directory."""
+"""Import layout step modules so Behave can discover their step definitions."""
 
-from tests.features.layout.auto_format_steps import *  # noqa: F401, F403
-from tests.features.layout.auto_layout_steps import *  # noqa: F401, F403
-from tests.features.layout.customize_layout_steps import *  # noqa: F401, F403
-from tests.features.layout.svg_export_steps import *  # noqa: F401, F403
+import tests.features.layout.auto_format_steps  # noqa: F401
+import tests.features.layout.auto_layout_steps  # noqa: F401
+import tests.features.layout.customize_layout_steps  # noqa: F401
+import tests.features.layout.svg_export_steps  # noqa: F401


### PR DESCRIPTION
## Summary

Post-merge cleanup following PR #82, addressing all issues flagged by SonarCloud, CodeQL, and the `github-code-quality` bot:

- **CI/BDD**: Fix `@wip` scenario handling — CI and pre-push now skip unimplemented routing scenarios; `pyproject.toml` `[tool.behave]` is the single source of truth for tag filtering
- **SonarCloud S1172** (unused parameters): Remove `resolution`, `grid_size`, `band_start_row`, `band_start_col` from function signatures across `layout/__init__.py` and `layout_engine.py`
- **SonarCloud S1940** (chained `startswith`): Replace with tuple form in `archimate_symbols.py`
- **CodeQL** (unused globals): Remove `_LAYER_PRIORITY` and `_ROWS_PER_LAYER` from `layout_engine.py`
- **CodeQL** (wildcard imports): Replace `from X import *` with `import X` in `layout_steps.py`; ruff F403 now guards future regressions without noqa suppression
- **Linting uplift**: Add `vulture` (unused code), ruff `ARG` (unused arguments, src-only), and ruff `C901` with `max-complexity=15` to catch these classes of issue locally before CI

## Test plan

- [ ] All existing unit and integration tests pass (235 unit, full integration suite)
- [ ] BDD suite runs cleanly with `@wip` scenarios skipped
- [ ] `poetry run vulture src/ --min-confidence 80` — clean
- [ ] `poetry run ruff check src/ tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)